### PR TITLE
Fix vault gun check

### DIFF
--- a/Main/LoadedTemplateManager.cs
+++ b/Main/LoadedTemplateManager.cs
@@ -121,28 +121,7 @@ namespace TNHFramework
         {
             if (!LoadedVaultFiles.ContainsKey(template.FileName))
             {
-                bool isFileBorked = false;
-                string culprit = "";
-                foreach (VaultObject vaultObject in template.Objects)
-                {
-                    foreach (VaultElement vaultElement in vaultObject.Elements)
-                    {
-                        if (!IM.OD.ContainsKey(vaultElement.ObjectID))
-                        {
-                            isFileBorked = true;
-                            culprit = vaultElement.ObjectID;
-                        }
-                    }
-                }
-
-                if (!isFileBorked)
-                {
-                    LoadedVaultFiles.Add(template.FileName, template);
-                }
-                else
-                {
-                    TNHFrameworkLogger.LogWarning("Failed to load vault file '" + template.FileName + "', culprit was: '" + culprit + "'");
-                }
+                LoadedVaultFiles.Add(template.FileName, template);
             }
         }
 

--- a/ObjectTemplates/SavedGunSerializable.cs
+++ b/ObjectTemplates/SavedGunSerializable.cs
@@ -61,15 +61,22 @@ namespace TNHFramework.ObjectTemplates
 
         public bool AllComponentsLoaded()
         {
-            foreach(SavedGunComponentSerializable component in Components)
+            bool result = true;
+            List<string> missing = [];
+
+            foreach (SavedGunComponentSerializable component in Components)
             {
                 if (!IM.OD.ContainsKey(component.ObjectID))
                 {
-                    return false;
+                    missing.Add(component.ObjectID);
+                    result = false;
                 }
             }
 
-            return true;
+            if (!result)
+                TNHFrameworkLogger.LogWarning($"Vaulted gun in table does not have all components loaded, removing it! VaultID: {FileName}, Missing ID(s): {string.Join(", ", [.. missing])}");
+
+            return result;
         }
 
         public FVRObject GetGunObject()

--- a/Utilities/TNHFrameworkUtils.cs
+++ b/Utilities/TNHFrameworkUtils.cs
@@ -511,23 +511,27 @@ namespace TNHFramework.Utilities
                     if (!IM.OD.ContainsKey(group.IDOverride[i]))
                     {
                         // If this is a vaulted gun with all it's components loaded, we should still have this in the object list
-                        if (LoadedTemplateManager.LoadedLegacyVaultFiles.ContainsKey(group.IDOverride[i]) && !LoadedTemplateManager.LoadedLegacyVaultFiles[group.IDOverride[i]].AllComponentsLoaded())
+                        if (LoadedTemplateManager.LoadedLegacyVaultFiles.ContainsKey(group.IDOverride[i]))
                         {
-                            TNHFrameworkLogger.LogWarning($"Vaulted gun in table does not have all components loaded, removing it! VaultID : {group.IDOverride[i]}");
-                            group.IDOverride.RemoveAt(i);
-                            i--;
+                            if (!LoadedTemplateManager.LoadedLegacyVaultFiles[group.IDOverride[i]].AllComponentsLoaded())
+                            {
+                                group.IDOverride.RemoveAt(i);
+                                i--;
+                            }
                         }
                         // If this is a vaulted gun with all it's components loaded, we should still have this in the object list
-                        else if (LoadedTemplateManager.LoadedVaultFiles.ContainsKey(group.IDOverride[i]) && !VaultFileComponentsLoaded(LoadedTemplateManager.LoadedVaultFiles[group.IDOverride[i]]))
+                        else if (LoadedTemplateManager.LoadedVaultFiles.ContainsKey(group.IDOverride[i]))
                         {
-                            TNHFrameworkLogger.LogWarning($"Vaulted gun in table does not have all components loaded! VaultID : {group.IDOverride[i]}");
-                            group.IDOverride.RemoveAt(i);
-                            i--;
+                            if (!VaultFileComponentsLoaded(LoadedTemplateManager.LoadedVaultFiles[group.IDOverride[i]]))
+                            {
+                                group.IDOverride.RemoveAt(i);
+                                i--;
+                            }
                         }
                         // If this is not a vaulted gun, remove it
                         else
                         {
-                            TNHFrameworkLogger.LogWarning($"Object in table not loaded, removing it from object table! ObjectID : {group.IDOverride[i]}");
+                            TNHFrameworkLogger.LogWarning($"Object in table not loaded, removing it from object table! ObjectID: {group.IDOverride[i]}");
                             group.IDOverride.RemoveAt(i);
                             i--;
                         }


### PR DESCRIPTION
New style vault guns were being checked for all components, but I think it was too early and needs to go into delayed init. I don't have a way of testing this that I know of.

Legacy vault guns were no longer being checked for components. I reverted it to how it was done in TNHTweaker, where vault guns (new and legacy) are always loaded at startup, but then checked later and removed from spawning when loading the character.

I added extra detail to the log messages to show what components are missing.