### PR TITLE
Minor bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+## [0.1.0] - 2024-07-04
+- First release, based on devyndamonster-TakeAndHoldTweaker 1.7.9.
+- Removed requirements for Deli and Magazine Patcher, now just optional.
+- Swapped plugin from loading via Deli to loading via Stratum.
+- Added support for loading custom characters via Stratum. Documentation is TBD.
+- YAML support added for character, sosig and vault files. Field format for characters has been overhauled, so they're not the same as the fields in character.json.
+- Added support for V2 vault files. Support is only available for Stratum-based custom characters.
+- Support is now included for Institution. Plugin checks if the current character is a vanilla character and will try to replicate Institution's changes if it is. If it's a custom character, it tries to be more faithful.
+- Added a Disabler feature. This is designed to allow for installing the original version alongside this custom fork - old custom characters require the original to function, but having both installed at the same time will conflict, thus, this renames the TakeAndHoldTweaker.deli file to prevent it from loading. It's not great, but it works.
+- Improved non-Magazine Patcher functionality. Had issues with Magazine Patcher not being present. This issue hasn't been reported, so it might've merely been an individual issue. Nonetheless, this should be better.
+- Removed HasPrimaryWeapon, HasSecondaryWeapon, booleans and just enable the pools based on whether they have been populated or not.
+- Removed "RequiredQuest", as it was an unfinished feature that didn't do anything.
+- Stratum only: Added "DespawnBetweenWaves" and "UsesVFX" booleans.
+  - DespawnBetweeenWaves (default=true): Causes any remaining sosigs to explode when the encryption phase in a Hold is completed.
+  - UsesVFX (default=true): Plays the "Encryption neatralized" announcer line when the encryption phase in a Hold is completed.
+- Prevent round types that cost tokens from being chosen when purchasing a firearm from the object constructor. Ammo that is spawned with the firearm is chosen from the list of "free" ones.
+- Expanded the character selection UI to allow more characters per category.
+- Fixed the bug where selecting past the 6th character wouldn't work.
+
+## [0.1.1] - 2024-07-04
+- Changed manifest to say TNHFramework instead of TNHTweaker. 
+
+## [0.1.2] - 2024-07-05
+- Added EnableScoring boolean to config in order to allow uploading of scores to custom TNH Dashboard.
+- Fixed character loader to load one character at a time.
+
+## [0.1.3] - 2024-09-03
+- EDIT: Forgot to push changes, so 0.1.3 is no different from 0.1.2.
+
+## [0.1.4] - 2024-09-05
+- Updated logger to say TNHFramework instead of TNHTweaker.
+- Fixed sosig item drops (e.g. PMC Pete, PorkUnknown).
+- Fixed patrol cadence. Patrols were always spawning immediately.
+
+## [0.1.5] - 2024-10-31
+
+### Features
+
+- Implemented sentry patrols (used in Institution) with loot and custom configs. Previously, it was only using non-Institution patrol behavior.
+- Added scanbox effect to all new panels when you place a valid item in the scan area.
+- Show total tokens and token cost on new panels when possible.
+- Added config file option to always change Mag Duplicator panel to Mag Upgrade panel, which was the default behavior in TNHTweaker.
+  - When option is disabled, "MagDuplicator" will be the old panel (with 2 options), while "MagUpgrader" will be the new one (with 3 options).
+- Added appropriate text title to each new panel.
+- Spawn each type of patrol before the same type is allowed to spawn again.
+- Added GlobalObjectBlacklist to character JSON.
+- Copy new vault files to output directory when using BuildCharacterFiles option.
+- Added "DisplayName" and "IsModdedContent" columns to Objects.csv when using BuildCharacterFiles option.
+- Show SosigEnemyIDs instead of numbers for custom sosigs in SosigIDs.txt when using BuildCharacterFiles option.
+- Filter out uninitialized data in internal mag patcher.
+- Added option to disable internal mag patcher even if MagazinePatcher is not detected.
+- Track all objects so they can be cleaned up quicker in order to save memory.
+- Vanilla characters use original behavior for supply boxes and token spawns, but custom characters use custom behavior.
+
+### Fixes
+
+- Fixed sosig item drops not working in Institution.
+- Fixed MagazinePatcher not being detected correctly.
+- Fixed random loot calls to use correct weights when subgroups are present.
+- Fixed random loot calls to be more robust.
+- Fixed scoring stats not being reset after Hold phase.
+- Fixed check that all components exist in vault guns.
+- Fixed logging not working when loading through Deli.
+- Fixed max number of sentry patrols.
+- Fixed loading of custom characters by validating JSON input.
+- Fixed tag handling for character and sosig JSON deserialization.
+- Fixed BespokeAttachmentChance not being checked when spawning a weapon case.
+- Fixed large cases being allowed to be purchased multiple times, causing clipping issues. Cases can only be purchased once per object constructor.
+- Fixed grenade spawn errors during Hold phase if GrenadeVectors do not exist.
+- Fixed sosigs being alerted when alert system is not enabled (vanilla bug).
+- Fixed GenerateSentryPatrol being called with incorrect parameters (vanilla bug).
+- Fixed wrong table being used in GetRandomSafeSupplyIndexFromHoldPoint (vanilla bug).
+- Fixed error sound being played when spawning a clip at the ammo reloader (vanilla bug).
+- Fixed vault pump action shotguns not spawning with the correct safety and chamber states (vanilla bug).
+- Fixed vault open bolt guns not spawning with the correct safety and chamber states (vanilla bug).
+- Fixed objects like loot drops failing to spawn sometimes.
+
+### Miscellaneous
+
+- Removed JSONBuilder because it wasn't being used and doesn't do anything anymore.
+- Removed high score submission because custom TNH Dashboard is permanently offline. This has been offline since before TNHFramework was created.
+- Internal mag patcher waits until OtherLoader finishes loading before running.
+- Internal mag patcher loads GameObjects when necessary to obtain metadata, unlike MagazinePatcher which loads ALL objects.
+- Remove dead sosigs BEFORE checking squads, instead of during the check itself.
+- Changed spawning method of vault guns to hopefully load them a little quicker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,12 @@
 - Internal mag patcher loads GameObjects when necessary to obtain metadata, unlike MagazinePatcher which loads ALL objects.
 - Remove dead sosigs BEFORE checking squads, instead of during the check itself.
 - Changed spawning method of vault guns to hopefully load them a little quicker.
+
+## [0.1.6] - 2025-XX-XX
+
+- Fixed patrol algorithm from skipping patrol types occassionally.
+- Fixed the case where the ammo blacklist removes all compatible rounds. It will now leave at least one type of round for each gun at the ammo spawner.
+- Fixed panels (ammo reloader, etc.) sometimes breaking when being used a lot.
+- Fixed the case where the secondary or tertiary starting item spawn point is missing from the map. This caused some characters to not work on certain maps (e.g. Aporkalypse Now).
+- Respect the HasPrimaryWeapon, HasSecondaryWeapon, etc. booleans. Some mod characters have an equipment pool populated, but disabled via boolean. This makes it consistent with old behavior.
+- Don't play the announcer line to advance to the next node after finishing the last hold (vanilla bug).

--- a/Main/ObjectWrappers/ObjectPanelWrapper.cs
+++ b/Main/ObjectWrappers/ObjectPanelWrapper.cs
@@ -63,7 +63,7 @@ namespace TNHFramework
             InitPanel();
             UpdateIcons();
 
-            GM.TNH_Manager.TokenCountChangeEvent += UpdateTokenDisplay;
+            original.M.TokenCountChangeEvent += UpdateTokenDisplay;
         }
 
         private void OnDestroy()
@@ -364,7 +364,7 @@ namespace TNHFramework
             DupeIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
             UpgradeIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
             PurchaseIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
-            int numTokens = GM.TNH_Manager.GetNumTokens();
+            int numTokens = original.M.GetNumTokens();
             numTokensSelected = 0;
 
             if (detectedMag != null || detectedSpeedLoader != null)
@@ -449,7 +449,7 @@ namespace TNHFramework
             InitPanel();
             UpdateIcons();
 
-            GM.TNH_Manager.TokenCountChangeEvent += UpdateTokenDisplay;
+            original.M.TokenCountChangeEvent += UpdateTokenDisplay;
         }
 
         private void OnDestroy()
@@ -633,7 +633,7 @@ namespace TNHFramework
         private void UpdateIcons()
         {
             PurchaseIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
-            int numTokens = GM.TNH_Manager.GetNumTokens();
+            int numTokens = original.M.GetNumTokens();
             numTokensSelected = 0;
 
             if (detectedFirearm != null)
@@ -700,7 +700,7 @@ namespace TNHFramework
             InitPanel();
             UpdateIcons();
 
-            GM.TNH_Manager.TokenCountChangeEvent += UpdateTokenDisplay;
+            original.M.TokenCountChangeEvent += UpdateTokenDisplay;
         }
 
         private void OnDestroy()
@@ -1028,7 +1028,7 @@ namespace TNHFramework
         private void UpdateIcons()
         {
             PurchaseIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
-            int numTokens = GM.TNH_Manager.GetNumTokens();
+            int numTokens = original.M.GetNumTokens();
             numTokensSelected = 0;
 
             if (detectedHandgun != null || detectedClosedBolt != null || detectedOpenBolt != null)
@@ -1100,7 +1100,7 @@ namespace TNHFramework
             InitPanel();
             UpdateIcons();
 
-            GM.TNH_Manager.TokenCountChangeEvent += UpdateTokenDisplay;
+            original.M.TokenCountChangeEvent += UpdateTokenDisplay;
         }
 
         private void OnDestroy()
@@ -1365,7 +1365,7 @@ namespace TNHFramework
         {
             PlusIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
             MinusIcon.State = TNH_ObjectConstructorIcon.IconState.Cancel;
-            int numTokens = GM.TNH_Manager.GetNumTokens();
+            int numTokens = original.M.GetNumTokens();
             numTokensSelected = 0;
 
             if (detectedHandgun != null || detectedClosedBolt != null || detectedOpenBolt != null)

--- a/Main/Patches/DebugPatches.cs
+++ b/Main/Patches/DebugPatches.cs
@@ -13,248 +13,248 @@ namespace TNHFramework
     public class DebugPatches
     {
 
-		[HarmonyPatch(typeof(TNH_Manager), "Start")]
-		[HarmonyPrefix]
-		public static bool AddPointDebugText(TNH_Manager __instance)
+        [HarmonyPatch(typeof(TNH_Manager), "Start")]
+        [HarmonyPrefix]
+        public static bool AddPointDebugText(TNH_Manager __instance)
         {
-			foreach(TNH_HoldPoint hold in __instance.HoldPoints)
+            foreach(TNH_HoldPoint hold in __instance.HoldPoints)
             {
 
-				TNHFrameworkLogger.Log("Adding text!", TNHFrameworkLogger.LogType.TNH);
+                TNHFrameworkLogger.Log("Adding text!", TNHFrameworkLogger.LogType.TNH);
 
-				GameObject canvas = new GameObject("Canvas");
-				canvas.transform.rotation = Quaternion.LookRotation(Vector3.right);
-				canvas.transform.position = hold.SpawnPoint_SystemNode.position + Vector3.up * 0.2f;
+                GameObject canvas = new GameObject("Canvas");
+                canvas.transform.rotation = Quaternion.LookRotation(Vector3.right);
+                canvas.transform.position = hold.SpawnPoint_SystemNode.position + Vector3.up * 0.2f;
 
-				Canvas canvasComp = canvas.AddComponent<Canvas>();
-				RectTransform rect = canvasComp.GetComponent<RectTransform>();
-				canvasComp.renderMode = RenderMode.WorldSpace;
-				rect.sizeDelta = new Vector2(1, 1);
+                Canvas canvasComp = canvas.AddComponent<Canvas>();
+                RectTransform rect = canvasComp.GetComponent<RectTransform>();
+                canvasComp.renderMode = RenderMode.WorldSpace;
+                rect.sizeDelta = new Vector2(1, 1);
 
-				GameObject text = new GameObject("Text");
-				text.transform.SetParent(canvas.transform);
-				text.transform.rotation = canvas.transform.rotation;
-				text.transform.localPosition = Vector3.zero;
+                GameObject text = new GameObject("Text");
+                text.transform.SetParent(canvas.transform);
+                text.transform.rotation = canvas.transform.rotation;
+                text.transform.localPosition = Vector3.zero;
 
-				text.AddComponent<CanvasRenderer>();
-				Text textComp = text.AddComponent<Text>();
-				Font ArialFont = (Font)Resources.GetBuiltinResource(typeof(Font), "Arial.ttf");
+                text.AddComponent<CanvasRenderer>();
+                Text textComp = text.AddComponent<Text>();
+                Font ArialFont = (Font)Resources.GetBuiltinResource(typeof(Font), "Arial.ttf");
 
-				textComp.text = "Hold " + __instance.HoldPoints.IndexOf(hold);
-				textComp.alignment = TextAnchor.MiddleCenter;
-				textComp.fontSize = 32;
-				text.transform.localScale = new Vector3(0.0015f, 0.0015f, 0.0015f);
-				textComp.font = ArialFont;
-				textComp.horizontalOverflow = HorizontalWrapMode.Overflow;
+                textComp.text = "Hold " + __instance.HoldPoints.IndexOf(hold);
+                textComp.alignment = TextAnchor.MiddleCenter;
+                textComp.fontSize = 32;
+                text.transform.localScale = new Vector3(0.0015f, 0.0015f, 0.0015f);
+                textComp.font = ArialFont;
+                textComp.horizontalOverflow = HorizontalWrapMode.Overflow;
             }
 
-			return true;
+            return true;
         }
 
 
-		/*
+        /*
         [HarmonyPatch(typeof(ObjectTable))] // Specify target method with HarmonyPatch attribute
-		[HarmonyPatch("Initialize")]
-		[HarmonyPatch(new Type[] { typeof(ObjectTableDef), typeof(FVRObject.ObjectCategory), typeof(List<FVRObject.OTagEra>), typeof(List<FVRObject.OTagSet>), typeof(List<FVRObject.OTagFirearmSize>), typeof(List<FVRObject.OTagFirearmAction>), typeof(List<FVRObject.OTagFirearmFiringMode>), typeof(List<FVRObject.OTagFirearmFiringMode>), typeof(List<FVRObject.OTagFirearmFeedOption>), typeof(List<FVRObject.OTagFirearmMount>), typeof(List<FVRObject.OTagFirearmRoundPower>), typeof(List<FVRObject.OTagAttachmentFeature>), typeof(List<FVRObject.OTagMeleeStyle>), typeof(List<FVRObject.OTagMeleeHandedness>), typeof(List<FVRObject.OTagFirearmMount>), typeof(List<FVRObject.OTagPowerupType>), typeof(List<FVRObject.OTagThrownType>), typeof(List<FVRObject.OTagThrownDamageType>), typeof(int), typeof(int), typeof(int), typeof(bool)})]
-		[HarmonyPrefix]
-		public static bool Initialize(ObjectTable __instance, ObjectTableDef Def, FVRObject.ObjectCategory category, List<FVRObject.OTagEra> eras, List<FVRObject.OTagSet> sets, List<FVRObject.OTagFirearmSize> sizes, List<FVRObject.OTagFirearmAction> actions, List<FVRObject.OTagFirearmFiringMode> modes, List<FVRObject.OTagFirearmFiringMode> excludeModes, List<FVRObject.OTagFirearmFeedOption> feedoptions, List<FVRObject.OTagFirearmMount> mountsavailable, List<FVRObject.OTagFirearmRoundPower> roundPowers, List<FVRObject.OTagAttachmentFeature> features, List<FVRObject.OTagMeleeStyle> meleeStyles, List<FVRObject.OTagMeleeHandedness> meleeHandedness, List<FVRObject.OTagFirearmMount> mounttype, List<FVRObject.OTagPowerupType> powerupTypes, List<FVRObject.OTagThrownType> thrownTypes, List<FVRObject.OTagThrownDamageType> thrownDamageTypes, int minCapacity, int maxCapacity, int requiredExactCapacity, bool isBlanked)
-		{
-			__instance.MinCapacity = minCapacity;
-			__instance.MaxCapacity = maxCapacity;
-			if (isBlanked)
-			{
-				TNHFrameworkLogger.Log("Table is blanked, not populating!", TNHFrameworkLogger.LogType.TNH);
-				return false;
-			}
-			if (Def.UseIDListOverride)
-			{
-				TNHFrameworkLogger.Log("Using IDOverride! Will only add IDs manually", TNHFrameworkLogger.LogType.TNH);
+        [HarmonyPatch("Initialize")]
+        [HarmonyPatch(new Type[] { typeof(ObjectTableDef), typeof(FVRObject.ObjectCategory), typeof(List<FVRObject.OTagEra>), typeof(List<FVRObject.OTagSet>), typeof(List<FVRObject.OTagFirearmSize>), typeof(List<FVRObject.OTagFirearmAction>), typeof(List<FVRObject.OTagFirearmFiringMode>), typeof(List<FVRObject.OTagFirearmFiringMode>), typeof(List<FVRObject.OTagFirearmFeedOption>), typeof(List<FVRObject.OTagFirearmMount>), typeof(List<FVRObject.OTagFirearmRoundPower>), typeof(List<FVRObject.OTagAttachmentFeature>), typeof(List<FVRObject.OTagMeleeStyle>), typeof(List<FVRObject.OTagMeleeHandedness>), typeof(List<FVRObject.OTagFirearmMount>), typeof(List<FVRObject.OTagPowerupType>), typeof(List<FVRObject.OTagThrownType>), typeof(List<FVRObject.OTagThrownDamageType>), typeof(int), typeof(int), typeof(int), typeof(bool)})]
+        [HarmonyPrefix]
+        public static bool Initialize(ObjectTable __instance, ObjectTableDef Def, FVRObject.ObjectCategory category, List<FVRObject.OTagEra> eras, List<FVRObject.OTagSet> sets, List<FVRObject.OTagFirearmSize> sizes, List<FVRObject.OTagFirearmAction> actions, List<FVRObject.OTagFirearmFiringMode> modes, List<FVRObject.OTagFirearmFiringMode> excludeModes, List<FVRObject.OTagFirearmFeedOption> feedoptions, List<FVRObject.OTagFirearmMount> mountsavailable, List<FVRObject.OTagFirearmRoundPower> roundPowers, List<FVRObject.OTagAttachmentFeature> features, List<FVRObject.OTagMeleeStyle> meleeStyles, List<FVRObject.OTagMeleeHandedness> meleeHandedness, List<FVRObject.OTagFirearmMount> mounttype, List<FVRObject.OTagPowerupType> powerupTypes, List<FVRObject.OTagThrownType> thrownTypes, List<FVRObject.OTagThrownDamageType> thrownDamageTypes, int minCapacity, int maxCapacity, int requiredExactCapacity, bool isBlanked)
+        {
+            __instance.MinCapacity = minCapacity;
+            __instance.MaxCapacity = maxCapacity;
+            if (isBlanked)
+            {
+                TNHFrameworkLogger.Log("Table is blanked, not populating!", TNHFrameworkLogger.LogType.TNH);
+                return false;
+            }
+            if (Def.UseIDListOverride)
+            {
+                TNHFrameworkLogger.Log("Using IDOverride! Will only add IDs manually", TNHFrameworkLogger.LogType.TNH);
 
-				for (int i = 0; i < Def.IDOverride.Count; i++)
-				{
-					__instance.Objs.Add(IM.OD[Def.IDOverride[i]]);
-				}
-				return false;
-			}
+                for (int i = 0; i < Def.IDOverride.Count; i++)
+                {
+                    __instance.Objs.Add(IM.OD[Def.IDOverride[i]]);
+                }
+                return false;
+            }
 
-			TNHFrameworkLogger.Log("Not using IDOverride, table will populate automatically", TNHFrameworkLogger.LogType.TNH);
+            TNHFrameworkLogger.Log("Not using IDOverride, table will populate automatically", TNHFrameworkLogger.LogType.TNH);
 
-			__instance.Objs = new List<FVRObject>(ManagerSingleton<IM>.Instance.odicTagCategory[category]);
+            __instance.Objs = new List<FVRObject>(ManagerSingleton<IM>.Instance.odicTagCategory[category]);
 
-			TNHFrameworkLogger.Log("Aquired all objects from Category (" + category + "), Listing them below", TNHFrameworkLogger.LogType.TNH);
-			TNHFrameworkLogger.Log(string.Join("\n", __instance.Objs.Select(o => o.ItemID).ToArray()), TNHFrameworkLogger.LogType.TNH);
+            TNHFrameworkLogger.Log("Aquired all objects from Category (" + category + "), Listing them below", TNHFrameworkLogger.LogType.TNH);
+            TNHFrameworkLogger.Log(string.Join("\n", __instance.Objs.Select(o => o.ItemID).ToArray()), TNHFrameworkLogger.LogType.TNH);
 
-			TNHFrameworkLogger.Log("Going through and removing items that do not match desired tags", TNHFrameworkLogger.LogType.TNH);
+            TNHFrameworkLogger.Log("Going through and removing items that do not match desired tags", TNHFrameworkLogger.LogType.TNH);
 
-			for (int j = __instance.Objs.Count - 1; j >= 0; j--)
-			{
-				FVRObject fvrobject = __instance.Objs[j];
-				TNHFrameworkLogger.Log("Looking at item (" + fvrobject.ItemID + ")", TNHFrameworkLogger.LogType.TNH);
+            for (int j = __instance.Objs.Count - 1; j >= 0; j--)
+            {
+                FVRObject fvrobject = __instance.Objs[j];
+                TNHFrameworkLogger.Log("Looking at item (" + fvrobject.ItemID + ")", TNHFrameworkLogger.LogType.TNH);
 
-				if (!fvrobject.OSple)
-				{
-					TNHFrameworkLogger.Log("OSple is false, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (minCapacity > -1 && fvrobject.MaxCapacityRelated < minCapacity)
-				{
-					TNHFrameworkLogger.Log("Magazines not big enough, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (maxCapacity > -1 && fvrobject.MinCapacityRelated > maxCapacity)
-				{
-					TNHFrameworkLogger.Log("Magazines not small enough, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (requiredExactCapacity > -1 && !__instance.DoesGunMatchExactCapacity(fvrobject))
-				{
-					TNHFrameworkLogger.Log("Not exact capacity, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (eras != null && eras.Count > 0 && !eras.Contains(fvrobject.TagEra))
-				{
-					TNHFrameworkLogger.Log("Wrong era, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (sets != null && sets.Count > 0 && !sets.Contains(fvrobject.TagSet))
-				{
-					TNHFrameworkLogger.Log("Wrong set, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (sizes != null && sizes.Count > 0 && !sizes.Contains(fvrobject.TagFirearmSize))
-				{
-					TNHFrameworkLogger.Log("Wrong size, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (actions != null && actions.Count > 0 && !actions.Contains(fvrobject.TagFirearmAction))
-				{
-					TNHFrameworkLogger.Log("Wrong actions, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else if (roundPowers != null && roundPowers.Count > 0 && !roundPowers.Contains(fvrobject.TagFirearmRoundPower))
-				{
-					TNHFrameworkLogger.Log("Wrong round power, removing", TNHFrameworkLogger.LogType.TNH);
-					__instance.Objs.RemoveAt(j);
-				}
-				else
-				{
-					if (modes != null && modes.Count > 0)
-					{
-						bool flag = false;
-						for (int k = 0; k < modes.Count; k++)
-						{
-							if (!fvrobject.TagFirearmFiringModes.Contains(modes[k]))
-							{
-								flag = true;
-								break;
-							}
-						}
-						if (flag)
-						{
-							TNHFrameworkLogger.Log("Wrong firing modes, removing", TNHFrameworkLogger.LogType.TNH);
-							__instance.Objs.RemoveAt(j);
-							break;
-						}
-					}
-					if (excludeModes != null)
-					{
-						bool flag2 = false;
-						for (int l = 0; l < excludeModes.Count; l++)
-						{
-							if (fvrobject.TagFirearmFiringModes.Contains(excludeModes[l]))
-							{
-								flag2 = true;
-								break;
-							}
-						}
-						if (flag2)
-						{
-							TNHFrameworkLogger.Log("Excluded firing modes, removing", TNHFrameworkLogger.LogType.TNH);
-							__instance.Objs.RemoveAt(j);
-							break;
-						}
-					}
-					if (feedoptions != null)
-					{
-						bool flag3 = false;
-						for (int m = 0; m < feedoptions.Count; m++)
-						{
-							if (!fvrobject.TagFirearmFeedOption.Contains(feedoptions[m]))
-							{
-								flag3 = true;
-								break;
-							}
-						}
-						if (flag3)
-						{
-							TNHFrameworkLogger.Log("Wrong feed options, removing", TNHFrameworkLogger.LogType.TNH);
-							__instance.Objs.RemoveAt(j);
-							break;
-						}
-					}
-					if (mountsavailable != null)
-					{
-						bool flag4 = false;
-						for (int n = 0; n < mountsavailable.Count; n++)
-						{
-							if (!fvrobject.TagFirearmMounts.Contains(mountsavailable[n]))
-							{
-								flag4 = true;
-								break;
-							}
-						}
-						if (flag4)
-						{
-							TNHFrameworkLogger.Log("Wrong mounts, removing", TNHFrameworkLogger.LogType.TNH);
-							__instance.Objs.RemoveAt(j);
-							break;
-						}
-					}
-					if (powerupTypes != null && powerupTypes.Count > 0 && !powerupTypes.Contains(fvrobject.TagPowerupType))
-					{
-						TNHFrameworkLogger.Log("Wrong powerup type, removing", TNHFrameworkLogger.LogType.TNH);
-						__instance.Objs.RemoveAt(j);
-					}
-					else if (thrownTypes != null && thrownTypes.Count > 0 && !thrownTypes.Contains(fvrobject.TagThrownType))
-					{
-						TNHFrameworkLogger.Log("Wrong thrown type, removing", TNHFrameworkLogger.LogType.TNH);
-						__instance.Objs.RemoveAt(j);
-					}
-					else if (thrownTypes != null && thrownTypes.Count > 0 && !thrownTypes.Contains(fvrobject.TagThrownType))
-					{
-						__instance.Objs.RemoveAt(j);
-					}
-					else if (meleeStyles != null && meleeStyles.Count > 0 && !meleeStyles.Contains(fvrobject.TagMeleeStyle))
-					{
-						TNHFrameworkLogger.Log("Wrong melee style, removing", TNHFrameworkLogger.LogType.TNH);
-						__instance.Objs.RemoveAt(j);
-					}
-					else if (meleeHandedness != null && meleeHandedness.Count > 0 && !meleeHandedness.Contains(fvrobject.TagMeleeHandedness))
-					{
-						TNHFrameworkLogger.Log("Wrong melee handedness, removing", TNHFrameworkLogger.LogType.TNH);
-						__instance.Objs.RemoveAt(j);
-					}
-					else if (mounttype != null && mounttype.Count > 0 && !mounttype.Contains(fvrobject.TagAttachmentMount))
-					{
-						TNHFrameworkLogger.Log("Wrong mount type, removing", TNHFrameworkLogger.LogType.TNH);
-						__instance.Objs.RemoveAt(j);
-					}
-					else if (features != null && features.Count > 0 && !features.Contains(fvrobject.TagAttachmentFeature))
-					{
-						TNHFrameworkLogger.Log("Wrong features, removing", TNHFrameworkLogger.LogType.TNH);
-						__instance.Objs.RemoveAt(j);
-					}
+                if (!fvrobject.OSple)
+                {
+                    TNHFrameworkLogger.Log("OSple is false, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (minCapacity > -1 && fvrobject.MaxCapacityRelated < minCapacity)
+                {
+                    TNHFrameworkLogger.Log("Magazines not big enough, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (maxCapacity > -1 && fvrobject.MinCapacityRelated > maxCapacity)
+                {
+                    TNHFrameworkLogger.Log("Magazines not small enough, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (requiredExactCapacity > -1 && !__instance.DoesGunMatchExactCapacity(fvrobject))
+                {
+                    TNHFrameworkLogger.Log("Not exact capacity, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (eras != null && eras.Count > 0 && !eras.Contains(fvrobject.TagEra))
+                {
+                    TNHFrameworkLogger.Log("Wrong era, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (sets != null && sets.Count > 0 && !sets.Contains(fvrobject.TagSet))
+                {
+                    TNHFrameworkLogger.Log("Wrong set, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (sizes != null && sizes.Count > 0 && !sizes.Contains(fvrobject.TagFirearmSize))
+                {
+                    TNHFrameworkLogger.Log("Wrong size, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (actions != null && actions.Count > 0 && !actions.Contains(fvrobject.TagFirearmAction))
+                {
+                    TNHFrameworkLogger.Log("Wrong actions, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else if (roundPowers != null && roundPowers.Count > 0 && !roundPowers.Contains(fvrobject.TagFirearmRoundPower))
+                {
+                    TNHFrameworkLogger.Log("Wrong round power, removing", TNHFrameworkLogger.LogType.TNH);
+                    __instance.Objs.RemoveAt(j);
+                }
+                else
+                {
+                    if (modes != null && modes.Count > 0)
+                    {
+                        bool flag = false;
+                        for (int k = 0; k < modes.Count; k++)
+                        {
+                            if (!fvrobject.TagFirearmFiringModes.Contains(modes[k]))
+                            {
+                                flag = true;
+                                break;
+                            }
+                        }
+                        if (flag)
+                        {
+                            TNHFrameworkLogger.Log("Wrong firing modes, removing", TNHFrameworkLogger.LogType.TNH);
+                            __instance.Objs.RemoveAt(j);
+                            break;
+                        }
+                    }
+                    if (excludeModes != null)
+                    {
+                        bool flag2 = false;
+                        for (int l = 0; l < excludeModes.Count; l++)
+                        {
+                            if (fvrobject.TagFirearmFiringModes.Contains(excludeModes[l]))
+                            {
+                                flag2 = true;
+                                break;
+                            }
+                        }
+                        if (flag2)
+                        {
+                            TNHFrameworkLogger.Log("Excluded firing modes, removing", TNHFrameworkLogger.LogType.TNH);
+                            __instance.Objs.RemoveAt(j);
+                            break;
+                        }
+                    }
+                    if (feedoptions != null)
+                    {
+                        bool flag3 = false;
+                        for (int m = 0; m < feedoptions.Count; m++)
+                        {
+                            if (!fvrobject.TagFirearmFeedOption.Contains(feedoptions[m]))
+                            {
+                                flag3 = true;
+                                break;
+                            }
+                        }
+                        if (flag3)
+                        {
+                            TNHFrameworkLogger.Log("Wrong feed options, removing", TNHFrameworkLogger.LogType.TNH);
+                            __instance.Objs.RemoveAt(j);
+                            break;
+                        }
+                    }
+                    if (mountsavailable != null)
+                    {
+                        bool flag4 = false;
+                        for (int n = 0; n < mountsavailable.Count; n++)
+                        {
+                            if (!fvrobject.TagFirearmMounts.Contains(mountsavailable[n]))
+                            {
+                                flag4 = true;
+                                break;
+                            }
+                        }
+                        if (flag4)
+                        {
+                            TNHFrameworkLogger.Log("Wrong mounts, removing", TNHFrameworkLogger.LogType.TNH);
+                            __instance.Objs.RemoveAt(j);
+                            break;
+                        }
+                    }
+                    if (powerupTypes != null && powerupTypes.Count > 0 && !powerupTypes.Contains(fvrobject.TagPowerupType))
+                    {
+                        TNHFrameworkLogger.Log("Wrong powerup type, removing", TNHFrameworkLogger.LogType.TNH);
+                        __instance.Objs.RemoveAt(j);
+                    }
+                    else if (thrownTypes != null && thrownTypes.Count > 0 && !thrownTypes.Contains(fvrobject.TagThrownType))
+                    {
+                        TNHFrameworkLogger.Log("Wrong thrown type, removing", TNHFrameworkLogger.LogType.TNH);
+                        __instance.Objs.RemoveAt(j);
+                    }
+                    else if (thrownTypes != null && thrownTypes.Count > 0 && !thrownTypes.Contains(fvrobject.TagThrownType))
+                    {
+                        __instance.Objs.RemoveAt(j);
+                    }
+                    else if (meleeStyles != null && meleeStyles.Count > 0 && !meleeStyles.Contains(fvrobject.TagMeleeStyle))
+                    {
+                        TNHFrameworkLogger.Log("Wrong melee style, removing", TNHFrameworkLogger.LogType.TNH);
+                        __instance.Objs.RemoveAt(j);
+                    }
+                    else if (meleeHandedness != null && meleeHandedness.Count > 0 && !meleeHandedness.Contains(fvrobject.TagMeleeHandedness))
+                    {
+                        TNHFrameworkLogger.Log("Wrong melee handedness, removing", TNHFrameworkLogger.LogType.TNH);
+                        __instance.Objs.RemoveAt(j);
+                    }
+                    else if (mounttype != null && mounttype.Count > 0 && !mounttype.Contains(fvrobject.TagAttachmentMount))
+                    {
+                        TNHFrameworkLogger.Log("Wrong mount type, removing", TNHFrameworkLogger.LogType.TNH);
+                        __instance.Objs.RemoveAt(j);
+                    }
+                    else if (features != null && features.Count > 0 && !features.Contains(fvrobject.TagAttachmentFeature))
+                    {
+                        TNHFrameworkLogger.Log("Wrong features, removing", TNHFrameworkLogger.LogType.TNH);
+                        __instance.Objs.RemoveAt(j);
+                    }
 
                     else
                     {
-						TNHFrameworkLogger.Log("Keeping item!", TNHFrameworkLogger.LogType.TNH);
-					}
-				}
-			}
+                        TNHFrameworkLogger.Log("Keeping item!", TNHFrameworkLogger.LogType.TNH);
+                    }
+                }
+            }
 
-			return false;
-		}
-		*/
+            return false;
+        }
+        */
 
-	}
+    }
 }

--- a/Main/Patches/PatrolPatches.cs
+++ b/Main/Patches/PatrolPatches.cs
@@ -472,15 +472,6 @@ namespace TNHFramework.Patches
         [HarmonyPrefix]
         public static bool GenerateValidPatrolReplacement(TNH_Manager __instance, int curStandardIndex, int excludeHoldIndex, bool isStart)
         {
-            CustomCharacter character = LoadedTemplateManager.LoadedCharactersDict[__instance.C];
-            Level currLevel = character.GetCurrentLevel(__instance.m_curLevel);
-
-            //Get a valid patrol index, and exit if there are no valid patrols
-            int patrolIndex = GetValidPatrolIndex(currLevel.Patrols);
-            if (patrolIndex == -1)
-                return false;
-
-            Patrol patrol = currLevel.Patrols[patrolIndex];
             List<int> validLocations = [];
             float minDist = __instance.TAHReticle.Range * 1.2f;
 
@@ -503,6 +494,15 @@ namespace TNHFramework.Patches
             if (validLocations.Count < 1) return false;
             validLocations.Shuffle();
 
+            CustomCharacter character = LoadedTemplateManager.LoadedCharactersDict[__instance.C];
+            Level currLevel = character.GetCurrentLevel(__instance.m_curLevel);
+
+            //Get a valid patrol index, and exit if there are no valid patrols
+            int patrolIndex = GetValidPatrolIndex(currLevel.Patrols);
+            if (patrolIndex == -1)
+                return false;
+
+            Patrol patrol = currLevel.Patrols[patrolIndex];
             TNH_Manager.SosigPatrolSquad squad = GeneratePatrol(__instance, validLocations[0], patrol, patrolIndex);
             __instance.m_patrolSquads.Add(squad);
 

--- a/Main/Patches/TNHPatches.cs
+++ b/Main/Patches/TNHPatches.cs
@@ -1620,6 +1620,7 @@ namespace TNHFramework.Patches
 
 
         [HarmonyPatch(typeof(TNH_ObjectConstructor), "ButtonClicked")] // Specify target method with HarmonyPatch attribute
+        [HarmonyPriority(800)]
         [HarmonyPrefix]
         public static bool ButtonClickedReplacement(TNH_ObjectConstructor __instance, int i)
         {

--- a/Main/Patches/TNHPatches.cs
+++ b/Main/Patches/TNHPatches.cs
@@ -399,7 +399,9 @@ namespace TNHFramework.Patches
 
                 if (selectedGroup != null)
                 {
-                    AnvilManager.Run(TNHFrameworkUtils.InstantiateFromEquipmentGroup(selectedGroup, __instance.SpawnPoints_SmallItem[1].position, __instance.SpawnPoints_SmallItem[1].rotation, o =>
+                    Transform spawnPoint = __instance.SpawnPoints_SmallItem.Count >= 2 ? __instance.SpawnPoints_SmallItem[1] : __instance.SpawnPoints_SmallItem[0];
+
+                    AnvilManager.Run(TNHFrameworkUtils.InstantiateFromEquipmentGroup(selectedGroup, spawnPoint.position, spawnPoint.rotation, o =>
                     {
                         __instance.M.AddObjectToTrackedList(o);
                     }));
@@ -412,7 +414,9 @@ namespace TNHFramework.Patches
 
                 if (selectedGroup != null)
                 {
-                    AnvilManager.Run(TNHFrameworkUtils.InstantiateFromEquipmentGroup(selectedGroup, __instance.SpawnPoints_SmallItem[2].position, __instance.SpawnPoints_SmallItem[2].rotation, o =>
+                    Transform spawnPoint = __instance.SpawnPoints_SmallItem.Count >= 3 ? __instance.SpawnPoints_SmallItem[2] : __instance.SpawnPoints_SmallItem[__instance.SpawnPoints_SmallItem.Count - 1];
+
+                    AnvilManager.Run(TNHFrameworkUtils.InstantiateFromEquipmentGroup(selectedGroup, spawnPoint.position, spawnPoint.rotation, o =>
                     {
                         __instance.M.AddObjectToTrackedList(o);
                     }));

--- a/ObjectTemplates/CustomCharacter.cs
+++ b/ObjectTemplates/CustomCharacter.cs
@@ -102,13 +102,13 @@ namespace TNHFramework.ObjectTemplates
             GlobalObjectBlacklist = [];
             GlobalAmmoBlacklist = [];
             MagazineBlacklist = [];
-            PrimaryWeapon = new LoadoutEntry(character.Weapon_Primary);
-            SecondaryWeapon = new LoadoutEntry(character.Weapon_Secondary);
-            TertiaryWeapon = new LoadoutEntry(character.Weapon_Tertiary);
-            PrimaryItem = new LoadoutEntry(character.Item_Primary);
-            SecondaryItem = new LoadoutEntry(character.Item_Secondary);
-            TertiaryItem = new LoadoutEntry(character.Item_Tertiary);
-            Shield = new LoadoutEntry(character.Item_Shield);
+            PrimaryWeapon = character.Has_Weapon_Primary ? new LoadoutEntry(character.Weapon_Primary) : new();
+            SecondaryWeapon = character.Has_Weapon_Secondary ? new LoadoutEntry(character.Weapon_Secondary) : new();
+            TertiaryWeapon = character.Has_Weapon_Tertiary ? new LoadoutEntry(character.Weapon_Tertiary) : new();
+            PrimaryItem = character.Has_Item_Primary ? new LoadoutEntry(character.Item_Primary) : new();
+            SecondaryItem = character.Has_Item_Secondary ? new LoadoutEntry(character.Item_Secondary) : new();
+            TertiaryItem = character.Has_Item_Tertiary ? new LoadoutEntry(character.Item_Tertiary) : new();
+            Shield = character.Has_Item_Shield ? new LoadoutEntry(character.Item_Shield) : new();
 
             RequireSightTable = new EquipmentGroup(character.RequireSightTable);
 
@@ -158,13 +158,13 @@ namespace TNHFramework.ObjectTemplates
             MagazineBlacklist = character.MagazineBlacklist ?? [];
 
             RequireSightTable = new EquipmentGroup(character.RequireSightTable);
-            PrimaryWeapon = new LoadoutEntry(character.PrimaryWeapon);
-            SecondaryWeapon = new LoadoutEntry(character.SecondaryWeapon);
-            TertiaryWeapon = new LoadoutEntry(character.TertiaryWeapon);
-            PrimaryItem = new LoadoutEntry(character.PrimaryItem);
-            SecondaryItem = new LoadoutEntry(character.SecondaryItem);
-            TertiaryItem = new LoadoutEntry(character.TertiaryItem);
-            Shield = new LoadoutEntry(character.Shield);
+            PrimaryWeapon = character.HasPrimaryWeapon? new LoadoutEntry(character.PrimaryWeapon) : new();
+            SecondaryWeapon = character.HasSecondaryWeapon ? new LoadoutEntry(character.SecondaryWeapon) : new();
+            TertiaryWeapon = character.HasTertiaryWeapon ? new LoadoutEntry(character.TertiaryWeapon) : new();
+            PrimaryItem = character.HasPrimaryItem ? new LoadoutEntry(character.PrimaryItem) : new();
+            SecondaryItem = character.HasSecondaryItem ? new LoadoutEntry(character.SecondaryItem) : new();
+            TertiaryItem = character.HasTertiaryItem ? new LoadoutEntry(character.TertiaryItem) : new();
+            Shield = character.HasShield ? new LoadoutEntry(character.Shield) : new();
 
             EquipmentPools = [];
             foreach (V1.EquipmentPool oldPool in character.EquipmentPools)

--- a/ObjectTemplates/SosigTemplate.cs
+++ b/ObjectTemplates/SosigTemplate.cs
@@ -25,8 +25,8 @@ namespace TNHFramework.ObjectTemplates
         public List<string> WeaponOptionsTertiary;
         public float SecondaryChance;
         public float TertiaryChance;
-		public float DroppedLootChance;
-		public V1.EquipmentGroup DroppedObjectPool;
+        public float DroppedLootChance;
+        public V1.EquipmentGroup DroppedObjectPool;
 
         [JsonIgnore]
         private SosigEnemyTemplate template;
@@ -46,18 +46,18 @@ namespace TNHFramework.ObjectTemplates
             WeaponOptionsSecondary = template.WeaponOptions_Secondary.Select(o => o.ItemID).ToList();
             WeaponOptionsTertiary = template.WeaponOptions_Tertiary.Select(o => o.ItemID).ToList();
 
-			Configs = template.ConfigTemplates.Select(o => new SosigConfig(o)).ToList();
-			ConfigsEasy = template.ConfigTemplates_Easy.Select(o => new SosigConfig(o)).ToList();
-			OutfitConfigs = template.OutfitConfig.Select(o => new OutfitConfig(o)).ToList();
+            Configs = template.ConfigTemplates.Select(o => new SosigConfig(o)).ToList();
+            ConfigsEasy = template.ConfigTemplates_Easy.Select(o => new SosigConfig(o)).ToList();
+            OutfitConfigs = template.OutfitConfig.Select(o => new OutfitConfig(o)).ToList();
 
-			DroppedLootChance = 0;
-			DroppedObjectPool = new();
+            DroppedLootChance = 0;
+            DroppedObjectPool = new();
 
-			this.template = template;
-		}
+            this.template = template;
+        }
 
-		public void Validate()
-		{
+        public void Validate()
+        {
             // Fix any null values that came from the JSON file
             SosigPrefabs ??= [];
 
@@ -89,67 +89,67 @@ namespace TNHFramework.ObjectTemplates
 
         public SosigEnemyTemplate GetSosigEnemyTemplate()
         {
-			if(template == null)
+            if(template == null)
             {
 
-				TNHFrameworkLogger.Log("Getting sosig template", TNHFrameworkLogger.LogType.Character);
+                TNHFrameworkLogger.Log("Getting sosig template", TNHFrameworkLogger.LogType.Character);
 
-				template = (SosigEnemyTemplate)ScriptableObject.CreateInstance(typeof(SosigEnemyTemplate));
+                template = (SosigEnemyTemplate)ScriptableObject.CreateInstance(typeof(SosigEnemyTemplate));
 
-				template.DisplayName = DisplayName;
-				template.SosigEnemyCategory = SosigEnemyCategory;
-				template.SecondaryChance = SecondaryChance;
-				template.TertiaryChance = TertiaryChance;
+                template.DisplayName = DisplayName;
+                template.SosigEnemyCategory = SosigEnemyCategory;
+                template.SecondaryChance = SecondaryChance;
+                template.TertiaryChance = TertiaryChance;
 
-				TNHFrameworkLogger.Log("Getting sosig config", TNHFrameworkLogger.LogType.Character);
-				template.ConfigTemplates = [];
-				foreach(SosigConfig temp in Configs)
+                TNHFrameworkLogger.Log("Getting sosig config", TNHFrameworkLogger.LogType.Character);
+                template.ConfigTemplates = [];
+                foreach(SosigConfig temp in Configs)
                 {
-					if(temp == null)
+                    if(temp == null)
                     {
-						TNHFrameworkLogger.LogError("One of the sosig configs is null!");
-						continue;
-					}
+                        TNHFrameworkLogger.LogError("One of the sosig configs is null!");
+                        continue;
+                    }
 
-					template.ConfigTemplates.Add(temp.GetConfigTemplate());
+                    template.ConfigTemplates.Add(temp.GetConfigTemplate());
                 }
 
-				template.ConfigTemplates_Easy = ConfigsEasy.Select(o => o.GetConfigTemplate()).ToList();
-				template.OutfitConfig = OutfitConfigs.Select(o => o.GetOutfitConfig()).ToList();
-			}
+                template.ConfigTemplates_Easy = ConfigsEasy.Select(o => o.GetConfigTemplate()).ToList();
+                template.OutfitConfig = OutfitConfigs.Select(o => o.GetOutfitConfig()).ToList();
+            }
 
-			return template;
+            return template;
         }
 
-		public void DelayedInit()
+        public void DelayedInit()
         {
-			if (template != null)
+            if (template != null)
             {
-				TNHFrameworkLogger.Log("Delayed init of sosig: " + DisplayName, TNHFrameworkLogger.LogType.Character);
+                TNHFrameworkLogger.Log("Delayed init of sosig: " + DisplayName, TNHFrameworkLogger.LogType.Character);
 
-				TNHFrameworkUtils.RemoveUnloadedObjectIDs(this);
+                TNHFrameworkUtils.RemoveUnloadedObjectIDs(this);
 
-				template.SosigPrefabs = SosigPrefabs.Select(o => IM.OD[o]).ToList();
-				template.WeaponOptions = WeaponOptions.Select(o => IM.OD[o]).ToList();
-				template.WeaponOptions_Secondary = WeaponOptionsSecondary.Select(o => IM.OD[o]).ToList();
-				template.WeaponOptions_Tertiary = WeaponOptionsTertiary.Select(o => IM.OD[o]).ToList();
+                template.SosigPrefabs = SosigPrefabs.Select(o => IM.OD[o]).ToList();
+                template.WeaponOptions = WeaponOptions.Select(o => IM.OD[o]).ToList();
+                template.WeaponOptions_Secondary = WeaponOptionsSecondary.Select(o => IM.OD[o]).ToList();
+                template.WeaponOptions_Tertiary = WeaponOptionsTertiary.Select(o => IM.OD[o]).ToList();
 
-				foreach(OutfitConfig outfit in OutfitConfigs)
+                foreach(OutfitConfig outfit in OutfitConfigs)
                 {
-					outfit.DelayedInit();
+                    outfit.DelayedInit();
                 }
 
-				if(DroppedObjectPool != null)
+                if(DroppedObjectPool != null)
                 {
-					DroppedObjectPool.DelayedInit();
-				}
-				
+                    DroppedObjectPool.DelayedInit();
+                }
+                
 				// Add the new sosig template to the global dictionaries
-				ManagerSingleton<IM>.Instance.odicSosigObjsByID.Add(template.SosigEnemyID, template);
-				ManagerSingleton<IM>.Instance.odicSosigIDsByCategory[template.SosigEnemyCategory].Add(template.SosigEnemyID);
-				ManagerSingleton<IM>.Instance.odicSosigObjsByCategory[template.SosigEnemyCategory].Add(template);
-			}
-		}
+                ManagerSingleton<IM>.Instance.odicSosigObjsByID.Add(template.SosigEnemyID, template);
+                ManagerSingleton<IM>.Instance.odicSosigIDsByCategory[template.SosigEnemyCategory].Add(template.SosigEnemyID);
+                ManagerSingleton<IM>.Instance.odicSosigObjsByCategory[template.SosigEnemyCategory].Add(template);
+            }
+        }
 
     }
 
@@ -168,120 +168,120 @@ namespace TNHFramework.ObjectTemplates
         public int TargetCapacity;
         public float TargetTrackingTime;
         public float NoFreshTargetTime;
-		public float AssaultPointOverridesSkirmishPointWhenFurtherThan;
-		public float RunSpeed;
-		public float WalkSpeed;
-		public float SneakSpeed;
-		public float CrawlSpeed;
-		public float TurnSpeed;
-		public float MaxJointLimit;
-		public float MovementRotMagnitude;
-		public float TotalMustard;
-		public float BleedDamageMult;
-		public float BleedRateMultiplier;
-		public float BleedVFXIntensity;
-		public float DamMult_Projectile;
-		public float DamMult_Explosive;
-		public float DamMult_Melee;
-		public float DamMult_Piercing;
-		public float DamMult_Blunt;
-		public float DamMult_Cutting;
-		public float DamMult_Thermal;
-		public float DamMult_Chilling;
-		public float DamMult_EMP;
-		public List<float> LinkDamageMultipliers;
-		public List<float> LinkStaggerMultipliers;
-		public List<Vector2Serializable> StartingLinkIntegrity;
-		public List<float> StartingChanceBrokenJoint;
-		public float ShudderThreshold;
-		public float ConfusionThreshold;
-		public float ConfusionMultiplier;
-		public float ConfusionTimeMax;
-		public float StunThreshold;
-		public float StunMultiplier;
-		public float StunTimeMax;
-		public bool CanBeGrabbed;
-		public bool CanBeSevered;
-		public bool CanBeStabbed;
-		public bool CanBeSurpressed;
-		public float SuppressionMult;
-		public bool DoesJointBreakKill_Head;
-		public bool DoesJointBreakKill_Upper;
-		public bool DoesJointBreakKill_Lower;
-		public bool DoesSeverKill_Head;
-		public bool DoesSeverKill_Upper;
-		public bool DoesSeverKill_Lower;
-		public bool DoesExplodeKill_Head;
-		public bool DoesExplodeKill_Upper;
-		public bool DoesExplodeKill_Lower;
+        public float AssaultPointOverridesSkirmishPointWhenFurtherThan;
+        public float RunSpeed;
+        public float WalkSpeed;
+        public float SneakSpeed;
+        public float CrawlSpeed;
+        public float TurnSpeed;
+        public float MaxJointLimit;
+        public float MovementRotMagnitude;
+        public float TotalMustard;
+        public float BleedDamageMult;
+        public float BleedRateMultiplier;
+        public float BleedVFXIntensity;
+        public float DamMult_Projectile;
+        public float DamMult_Explosive;
+        public float DamMult_Melee;
+        public float DamMult_Piercing;
+        public float DamMult_Blunt;
+        public float DamMult_Cutting;
+        public float DamMult_Thermal;
+        public float DamMult_Chilling;
+        public float DamMult_EMP;
+        public List<float> LinkDamageMultipliers;
+        public List<float> LinkStaggerMultipliers;
+        public List<Vector2Serializable> StartingLinkIntegrity;
+        public List<float> StartingChanceBrokenJoint;
+        public float ShudderThreshold;
+        public float ConfusionThreshold;
+        public float ConfusionMultiplier;
+        public float ConfusionTimeMax;
+        public float StunThreshold;
+        public float StunMultiplier;
+        public float StunTimeMax;
+        public bool CanBeGrabbed;
+        public bool CanBeSevered;
+        public bool CanBeStabbed;
+        public bool CanBeSurpressed;
+        public float SuppressionMult;
+        public bool DoesJointBreakKill_Head;
+        public bool DoesJointBreakKill_Upper;
+        public bool DoesJointBreakKill_Lower;
+        public bool DoesSeverKill_Head;
+        public bool DoesSeverKill_Upper;
+        public bool DoesSeverKill_Lower;
+        public bool DoesExplodeKill_Head;
+        public bool DoesExplodeKill_Upper;
+        public bool DoesExplodeKill_Lower;
 
         [JsonIgnore]
         private SosigConfigTemplate template;
 
-		public SosigConfig() { }
+        public SosigConfig() { }
         public SosigConfig(SosigConfigTemplate template)
         {
-			ViewDistance = template.ViewDistance;
-			HearingDistance = template.HearingDistance;
-			MaxFOV = template.MaxFOV;
-			SearchExtentsModifier = template.SearchExtentsModifier;
-			DoesAggroOnFriendlyFire = template.DoesAggroOnFriendlyFire;
-			HasABrain = template.HasABrain;
-			DoesDropWeaponsOnBallistic = template.DoesDropWeaponsOnBallistic;
-			CanPickupRanged = template.CanPickup_Ranged;
-			CanPickupMelee = template.CanPickup_Melee;
-			CanPickupOther = template.CanPickup_Other;
-			TargetCapacity = template.TargetCapacity;
-			TargetTrackingTime = template.TargetTrackingTime;
-			NoFreshTargetTime = template.NoFreshTargetTime;
-			AssaultPointOverridesSkirmishPointWhenFurtherThan = template.AssaultPointOverridesSkirmishPointWhenFurtherThan;
-			RunSpeed = template.RunSpeed;
-			WalkSpeed = template.WalkSpeed;
-			SneakSpeed = template.SneakSpeed;
-			CrawlSpeed = template.CrawlSpeed;
-			TurnSpeed = template.TurnSpeed;
-			MaxJointLimit = template.MaxJointLimit;
-			MovementRotMagnitude = template.MovementRotMagnitude;
-			TotalMustard = template.TotalMustard;
-			BleedDamageMult = template.BleedDamageMult;
-			BleedRateMultiplier = template.BleedRateMultiplier;
-			BleedVFXIntensity = template.BleedVFXIntensity;
-			DamMult_Projectile = template.DamMult_Projectile;
-			DamMult_Explosive = template.DamMult_Explosive;
-			DamMult_Melee = template.DamMult_Melee;
-			DamMult_Piercing = template.DamMult_Piercing;
-			DamMult_Blunt = template.DamMult_Blunt;
-			DamMult_Cutting = template.DamMult_Cutting;
-			DamMult_Thermal = template.DamMult_Thermal;
-			DamMult_Chilling = template.DamMult_Chilling;
-			DamMult_EMP = template.DamMult_EMP;
-			LinkDamageMultipliers = template.LinkDamageMultipliers;
-			LinkStaggerMultipliers = template.LinkStaggerMultipliers;
-			StartingLinkIntegrity = template.StartingLinkIntegrity.Select(o => new Vector2Serializable(o)).ToList();
-			StartingChanceBrokenJoint = template.StartingChanceBrokenJoint;
-			ShudderThreshold = template.ShudderThreshold;
-			ConfusionThreshold = template.ConfusionThreshold;
-			ConfusionMultiplier = template.ConfusionMultiplier;
-			ConfusionTimeMax = template.ConfusionTimeMax;
-			StunThreshold = template.StunThreshold;
-			StunMultiplier = template.StunMultiplier;
-			StunTimeMax = template.StunTimeMax;
-			CanBeGrabbed = template.CanBeGrabbed;
-			CanBeSevered = template.CanBeSevered;
-			CanBeStabbed = template.CanBeStabbed;
-			CanBeSurpressed = template.CanBeSurpressed;
-			SuppressionMult = template.SuppressionMult;
-			DoesJointBreakKill_Head = template.DoesJointBreakKill_Head;
-			DoesJointBreakKill_Upper = template.DoesJointBreakKill_Upper;
-			DoesJointBreakKill_Lower = template.DoesJointBreakKill_Lower;
-			DoesSeverKill_Head = template.DoesSeverKill_Head;
-			DoesSeverKill_Upper = template.DoesSeverKill_Upper;
-			DoesSeverKill_Lower = template.DoesSeverKill_Lower;
-			DoesExplodeKill_Head = template.DoesExplodeKill_Head;
-			DoesExplodeKill_Upper = template.DoesExplodeKill_Upper;
-			DoesExplodeKill_Lower = template.DoesExplodeKill_Lower;
+            ViewDistance = template.ViewDistance;
+            HearingDistance = template.HearingDistance;
+            MaxFOV = template.MaxFOV;
+            SearchExtentsModifier = template.SearchExtentsModifier;
+            DoesAggroOnFriendlyFire = template.DoesAggroOnFriendlyFire;
+            HasABrain = template.HasABrain;
+            DoesDropWeaponsOnBallistic = template.DoesDropWeaponsOnBallistic;
+            CanPickupRanged = template.CanPickup_Ranged;
+            CanPickupMelee = template.CanPickup_Melee;
+            CanPickupOther = template.CanPickup_Other;
+            TargetCapacity = template.TargetCapacity;
+            TargetTrackingTime = template.TargetTrackingTime;
+            NoFreshTargetTime = template.NoFreshTargetTime;
+            AssaultPointOverridesSkirmishPointWhenFurtherThan = template.AssaultPointOverridesSkirmishPointWhenFurtherThan;
+            RunSpeed = template.RunSpeed;
+            WalkSpeed = template.WalkSpeed;
+            SneakSpeed = template.SneakSpeed;
+            CrawlSpeed = template.CrawlSpeed;
+            TurnSpeed = template.TurnSpeed;
+            MaxJointLimit = template.MaxJointLimit;
+            MovementRotMagnitude = template.MovementRotMagnitude;
+            TotalMustard = template.TotalMustard;
+            BleedDamageMult = template.BleedDamageMult;
+            BleedRateMultiplier = template.BleedRateMultiplier;
+            BleedVFXIntensity = template.BleedVFXIntensity;
+            DamMult_Projectile = template.DamMult_Projectile;
+            DamMult_Explosive = template.DamMult_Explosive;
+            DamMult_Melee = template.DamMult_Melee;
+            DamMult_Piercing = template.DamMult_Piercing;
+            DamMult_Blunt = template.DamMult_Blunt;
+            DamMult_Cutting = template.DamMult_Cutting;
+            DamMult_Thermal = template.DamMult_Thermal;
+            DamMult_Chilling = template.DamMult_Chilling;
+            DamMult_EMP = template.DamMult_EMP;
+            LinkDamageMultipliers = template.LinkDamageMultipliers;
+            LinkStaggerMultipliers = template.LinkStaggerMultipliers;
+            StartingLinkIntegrity = template.StartingLinkIntegrity.Select(o => new Vector2Serializable(o)).ToList();
+            StartingChanceBrokenJoint = template.StartingChanceBrokenJoint;
+            ShudderThreshold = template.ShudderThreshold;
+            ConfusionThreshold = template.ConfusionThreshold;
+            ConfusionMultiplier = template.ConfusionMultiplier;
+            ConfusionTimeMax = template.ConfusionTimeMax;
+            StunThreshold = template.StunThreshold;
+            StunMultiplier = template.StunMultiplier;
+            StunTimeMax = template.StunTimeMax;
+            CanBeGrabbed = template.CanBeGrabbed;
+            CanBeSevered = template.CanBeSevered;
+            CanBeStabbed = template.CanBeStabbed;
+            CanBeSurpressed = template.CanBeSurpressed;
+            SuppressionMult = template.SuppressionMult;
+            DoesJointBreakKill_Head = template.DoesJointBreakKill_Head;
+            DoesJointBreakKill_Upper = template.DoesJointBreakKill_Upper;
+            DoesJointBreakKill_Lower = template.DoesJointBreakKill_Lower;
+            DoesSeverKill_Head = template.DoesSeverKill_Head;
+            DoesSeverKill_Upper = template.DoesSeverKill_Upper;
+            DoesSeverKill_Lower = template.DoesSeverKill_Lower;
+            DoesExplodeKill_Head = template.DoesExplodeKill_Head;
+            DoesExplodeKill_Upper = template.DoesExplodeKill_Upper;
+            DoesExplodeKill_Lower = template.DoesExplodeKill_Lower;
 
-			this.template = template;
+            this.template = template;
         }
 
         public void Validate()
@@ -292,135 +292,135 @@ namespace TNHFramework.ObjectTemplates
             StartingChanceBrokenJoint ??= [];
         }
 
-		public SosigConfigTemplate GetConfigTemplate()
+        public SosigConfigTemplate GetConfigTemplate()
         {
-			if(template == null)
+            if(template == null)
             {
-				template = (SosigConfigTemplate)ScriptableObject.CreateInstance(typeof(SosigConfigTemplate));
+                template = (SosigConfigTemplate)ScriptableObject.CreateInstance(typeof(SosigConfigTemplate));
 
-				template.ViewDistance = ViewDistance;
-				template.HearingDistance = HearingDistance;
-				template.MaxFOV = MaxFOV;
-				template.SearchExtentsModifier = SearchExtentsModifier;
-				template.DoesAggroOnFriendlyFire = DoesAggroOnFriendlyFire;
-				template.HasABrain = HasABrain;
-				template.DoesDropWeaponsOnBallistic = DoesDropWeaponsOnBallistic;
-				template.CanPickup_Ranged = CanPickupRanged;
-				template.CanPickup_Melee = CanPickupMelee;
-				template.CanPickup_Other = CanPickupOther;
-				template.TargetCapacity = TargetCapacity;
-				template.TargetTrackingTime = TargetTrackingTime;
-				template.NoFreshTargetTime = NoFreshTargetTime;
-				template.AssaultPointOverridesSkirmishPointWhenFurtherThan = AssaultPointOverridesSkirmishPointWhenFurtherThan;
-				template.RunSpeed = RunSpeed;
-				template.WalkSpeed = WalkSpeed;
-				template.SneakSpeed = SneakSpeed;
-				template.CrawlSpeed = CrawlSpeed;
-				template.TurnSpeed = TurnSpeed;
-				template.MaxJointLimit = MaxJointLimit;
-				template.MovementRotMagnitude = MovementRotMagnitude;
-				template.TotalMustard =	TotalMustard;
-				template.BleedDamageMult = BleedDamageMult;
-				template.BleedRateMultiplier = BleedRateMultiplier;
-				template.BleedVFXIntensity = BleedVFXIntensity;
-				template.DamMult_Projectile = DamMult_Projectile;
-				template.DamMult_Explosive = DamMult_Explosive;
-				template.DamMult_Melee = DamMult_Melee;
-				template.DamMult_Piercing = DamMult_Piercing;
-				template.DamMult_Blunt = DamMult_Blunt;
-				template.DamMult_Cutting = DamMult_Cutting;
-				template.DamMult_Thermal = DamMult_Thermal;
-				template.DamMult_Chilling = DamMult_Chilling;
-				template.DamMult_EMP = DamMult_EMP;
-				template.LinkDamageMultipliers = LinkDamageMultipliers;
-				template.LinkStaggerMultipliers = LinkStaggerMultipliers;
+                template.ViewDistance = ViewDistance;
+                template.HearingDistance = HearingDistance;
+                template.MaxFOV = MaxFOV;
+                template.SearchExtentsModifier = SearchExtentsModifier;
+                template.DoesAggroOnFriendlyFire = DoesAggroOnFriendlyFire;
+                template.HasABrain = HasABrain;
+                template.DoesDropWeaponsOnBallistic = DoesDropWeaponsOnBallistic;
+                template.CanPickup_Ranged = CanPickupRanged;
+                template.CanPickup_Melee = CanPickupMelee;
+                template.CanPickup_Other = CanPickupOther;
+                template.TargetCapacity = TargetCapacity;
+                template.TargetTrackingTime = TargetTrackingTime;
+                template.NoFreshTargetTime = NoFreshTargetTime;
+                template.AssaultPointOverridesSkirmishPointWhenFurtherThan = AssaultPointOverridesSkirmishPointWhenFurtherThan;
+                template.RunSpeed = RunSpeed;
+                template.WalkSpeed = WalkSpeed;
+                template.SneakSpeed = SneakSpeed;
+                template.CrawlSpeed = CrawlSpeed;
+                template.TurnSpeed = TurnSpeed;
+                template.MaxJointLimit = MaxJointLimit;
+                template.MovementRotMagnitude = MovementRotMagnitude;
+                template.TotalMustard =	TotalMustard;
+                template.BleedDamageMult = BleedDamageMult;
+                template.BleedRateMultiplier = BleedRateMultiplier;
+                template.BleedVFXIntensity = BleedVFXIntensity;
+                template.DamMult_Projectile = DamMult_Projectile;
+                template.DamMult_Explosive = DamMult_Explosive;
+                template.DamMult_Melee = DamMult_Melee;
+                template.DamMult_Piercing = DamMult_Piercing;
+                template.DamMult_Blunt = DamMult_Blunt;
+                template.DamMult_Cutting = DamMult_Cutting;
+                template.DamMult_Thermal = DamMult_Thermal;
+                template.DamMult_Chilling = DamMult_Chilling;
+                template.DamMult_EMP = DamMult_EMP;
+                template.LinkDamageMultipliers = LinkDamageMultipliers;
+                template.LinkStaggerMultipliers = LinkStaggerMultipliers;
 
-				template.StartingLinkIntegrity = [];
-				foreach (Vector2Serializable v in StartingLinkIntegrity)
-				{
-					template.StartingLinkIntegrity.Add(v.GetVector2());
-				}
+                template.StartingLinkIntegrity = [];
+                foreach (Vector2Serializable v in StartingLinkIntegrity)
+                {
+                    template.StartingLinkIntegrity.Add(v.GetVector2());
+                }
 
-				template.StartingChanceBrokenJoint = StartingChanceBrokenJoint;
-				template.ShudderThreshold = ShudderThreshold;
-				template.ConfusionThreshold = ConfusionThreshold;
-				template.ConfusionMultiplier = ConfusionMultiplier;
-				template.ConfusionTimeMax = ConfusionTimeMax;
-				template.StunThreshold = StunThreshold;
-				template.StunMultiplier = StunMultiplier;
-				template.StunTimeMax = StunTimeMax;
-				template.CanBeGrabbed = CanBeGrabbed;
-				template.CanBeSevered = CanBeSevered;
-				template.CanBeStabbed = CanBeStabbed;
-				template.CanBeSurpressed = CanBeSurpressed;
-				template.SuppressionMult = SuppressionMult;
-				template.DoesJointBreakKill_Head = DoesJointBreakKill_Head;
-				template.DoesJointBreakKill_Upper = DoesJointBreakKill_Upper;
-				template.DoesJointBreakKill_Lower = DoesJointBreakKill_Lower;
-				template.DoesSeverKill_Head = DoesSeverKill_Head;
-				template.DoesSeverKill_Upper = DoesSeverKill_Upper;
-				template.DoesSeverKill_Lower = DoesSeverKill_Lower;
-				template.DoesExplodeKill_Head = DoesExplodeKill_Head;
-				template.DoesExplodeKill_Upper = DoesExplodeKill_Upper;
-				template.DoesExplodeKill_Lower = DoesExplodeKill_Lower;
-				template.UsesLinkSpawns = false;
-				template.LinkSpawns = [];
-				template.LinkSpawnChance = [];
-				template.OverrideSpeech = false;
-			}
+                template.StartingChanceBrokenJoint = StartingChanceBrokenJoint;
+                template.ShudderThreshold = ShudderThreshold;
+                template.ConfusionThreshold = ConfusionThreshold;
+                template.ConfusionMultiplier = ConfusionMultiplier;
+                template.ConfusionTimeMax = ConfusionTimeMax;
+                template.StunThreshold = StunThreshold;
+                template.StunMultiplier = StunMultiplier;
+                template.StunTimeMax = StunTimeMax;
+                template.CanBeGrabbed = CanBeGrabbed;
+                template.CanBeSevered = CanBeSevered;
+                template.CanBeStabbed = CanBeStabbed;
+                template.CanBeSurpressed = CanBeSurpressed;
+                template.SuppressionMult = SuppressionMult;
+                template.DoesJointBreakKill_Head = DoesJointBreakKill_Head;
+                template.DoesJointBreakKill_Upper = DoesJointBreakKill_Upper;
+                template.DoesJointBreakKill_Lower = DoesJointBreakKill_Lower;
+                template.DoesSeverKill_Head = DoesSeverKill_Head;
+                template.DoesSeverKill_Upper = DoesSeverKill_Upper;
+                template.DoesSeverKill_Lower = DoesSeverKill_Lower;
+                template.DoesExplodeKill_Head = DoesExplodeKill_Head;
+                template.DoesExplodeKill_Upper = DoesExplodeKill_Upper;
+                template.DoesExplodeKill_Lower = DoesExplodeKill_Lower;
+                template.UsesLinkSpawns = false;
+                template.LinkSpawns = [];
+                template.LinkSpawnChance = [];
+                template.OverrideSpeech = false;
+            }
 
-			return template;
+            return template;
         }
 
-	}
+    }
 
     public class OutfitConfig
     {
-		public List<string> Headwear;
-		public float Chance_Headwear;
-		public bool ForceWearAllHead;
-		public List<string> Eyewear;
-		public float Chance_Eyewear;
-		public bool ForceWearAllEye;
-		public List<string> Facewear;
-		public float Chance_Facewear;
-		public bool ForceWearAllFace;
-		public List<string> Torsowear;
-		public float Chance_Torsowear;
-		public bool ForceWearAllTorso;
-		public List<string> Pantswear;
-		public float Chance_Pantswear;
-		public bool ForceWearAllPants;
-		public List<string> Pantswear_Lower;
-		public float Chance_Pantswear_Lower;
-		public bool ForceWearAllPantsLower;
-		public List<string> Backpacks;
-		public float Chance_Backpacks;
-		public bool ForceWearAllBackpacks;
+        public List<string> Headwear;
+        public float Chance_Headwear;
+        public bool ForceWearAllHead;
+        public List<string> Eyewear;
+        public float Chance_Eyewear;
+        public bool ForceWearAllEye;
+        public List<string> Facewear;
+        public float Chance_Facewear;
+        public bool ForceWearAllFace;
+        public List<string> Torsowear;
+        public float Chance_Torsowear;
+        public bool ForceWearAllTorso;
+        public List<string> Pantswear;
+        public float Chance_Pantswear;
+        public bool ForceWearAllPants;
+        public List<string> Pantswear_Lower;
+        public float Chance_Pantswear_Lower;
+        public bool ForceWearAllPantsLower;
+        public List<string> Backpacks;
+        public float Chance_Backpacks;
+        public bool ForceWearAllBackpacks;
 
-		[JsonIgnore]
-		private SosigOutfitConfig template;
+        [JsonIgnore]
+        private SosigOutfitConfig template;
 
-		public OutfitConfig() { }
+        public OutfitConfig() { }
 
-		public OutfitConfig(SosigOutfitConfig template)
+        public OutfitConfig(SosigOutfitConfig template)
         {
-			Headwear = template.Headwear.Select(o => o.ItemID).ToList();
-			Eyewear = template.Eyewear.Select(o => o.ItemID).ToList();
-			Facewear = template.Facewear.Select(o => o.ItemID).ToList();
-			Torsowear = template.Torsowear.Select(o => o.ItemID).ToList();
-			Pantswear = template.Pantswear.Select(o => o.ItemID).ToList();
-			Pantswear_Lower = template.Pantswear_Lower.Select(o => o.ItemID).ToList();
-			Backpacks = template.Backpacks.Select(o => o.ItemID).ToList();
-			Chance_Headwear = template.Chance_Headwear;
-			Chance_Eyewear = template.Chance_Eyewear;
-			Chance_Facewear = template.Chance_Facewear;
-			Chance_Torsowear = template.Chance_Torsowear;
-			Chance_Pantswear = template.Chance_Pantswear;
-			Chance_Pantswear_Lower = template.Chance_Pantswear_Lower;
-			Chance_Backpacks = template.Chance_Backpacks;
+            Headwear = template.Headwear.Select(o => o.ItemID).ToList();
+            Eyewear = template.Eyewear.Select(o => o.ItemID).ToList();
+            Facewear = template.Facewear.Select(o => o.ItemID).ToList();
+            Torsowear = template.Torsowear.Select(o => o.ItemID).ToList();
+            Pantswear = template.Pantswear.Select(o => o.ItemID).ToList();
+            Pantswear_Lower = template.Pantswear_Lower.Select(o => o.ItemID).ToList();
+            Backpacks = template.Backpacks.Select(o => o.ItemID).ToList();
+            Chance_Headwear = template.Chance_Headwear;
+            Chance_Eyewear = template.Chance_Eyewear;
+            Chance_Facewear = template.Chance_Facewear;
+            Chance_Torsowear = template.Chance_Torsowear;
+            Chance_Pantswear = template.Chance_Pantswear;
+            Chance_Pantswear_Lower = template.Chance_Pantswear_Lower;
+            Chance_Backpacks = template.Chance_Backpacks;
 
-			this.template = template;
+            this.template = template;
         }
 
         public void Validate()
@@ -434,34 +434,34 @@ namespace TNHFramework.ObjectTemplates
             Backpacks ??= [];
         }
 
-		public SosigOutfitConfig GetOutfitConfig()
+        public SosigOutfitConfig GetOutfitConfig()
         {
-			if(template == null)
+            if(template == null)
             {
-				template = (SosigOutfitConfig)ScriptableObject.CreateInstance(typeof(SosigOutfitConfig));
-				
-				template.Chance_Headwear = Chance_Headwear;
-				template.Chance_Eyewear = Chance_Eyewear;
-				template.Chance_Facewear = Chance_Facewear;
-				template.Chance_Torsowear = Chance_Torsowear;
-				template.Chance_Pantswear = Chance_Pantswear;
-				template.Chance_Pantswear_Lower = Chance_Pantswear_Lower;
-				template.Chance_Backpacks = Chance_Backpacks;
-			}
+                template = (SosigOutfitConfig)ScriptableObject.CreateInstance(typeof(SosigOutfitConfig));
+                
+                template.Chance_Headwear = Chance_Headwear;
+                template.Chance_Eyewear = Chance_Eyewear;
+                template.Chance_Facewear = Chance_Facewear;
+                template.Chance_Torsowear = Chance_Torsowear;
+                template.Chance_Pantswear = Chance_Pantswear;
+                template.Chance_Pantswear_Lower = Chance_Pantswear_Lower;
+                template.Chance_Backpacks = Chance_Backpacks;
+            }
 
-			return template;
+            return template;
         }
 
-		public void DelayedInit()
+        public void DelayedInit()
         {
-			template.Headwear = Headwear.Select(o => IM.OD[o]).ToList();
-			template.Eyewear = Eyewear.Select(o => IM.OD[o]).ToList();
-			template.Facewear = Facewear.Select(o => IM.OD[o]).ToList();
-			template.Torsowear = Torsowear.Select(o => IM.OD[o]).ToList();
-			template.Pantswear = Pantswear.Select(o => IM.OD[o]).ToList();
-			template.Pantswear_Lower = Pantswear_Lower.Select(o => IM.OD[o]).ToList();
-			template.Backpacks = Backpacks.Select(o => IM.OD[o]).ToList();
-		}
+            template.Headwear = Headwear.Select(o => IM.OD[o]).ToList();
+            template.Eyewear = Eyewear.Select(o => IM.OD[o]).ToList();
+            template.Facewear = Facewear.Select(o => IM.OD[o]).ToList();
+            template.Torsowear = Torsowear.Select(o => IM.OD[o]).ToList();
+            template.Pantswear = Pantswear.Select(o => IM.OD[o]).ToList();
+            template.Pantswear_Lower = Pantswear_Lower.Select(o => IM.OD[o]).ToList();
+            template.Backpacks = Backpacks.Select(o => IM.OD[o]).ToList();
+        }
 
-	}
+    }
 }

--- a/Utilities/FirearmUtils.cs
+++ b/Utilities/FirearmUtils.cs
@@ -181,7 +181,15 @@ namespace TNHFramework.Utilities
             //Go through these containers and remove any that don't fit given criteria
             for (int i = compatibleRounds.Count - 1; i >= 0; i--)
             {
-                if (blacklist != null && !blacklist.IsRoundAllowed(compatibleRounds[i].ItemID))
+                if (compatibleRounds.Count <= 1)
+                    break;
+
+                if (!eras.Contains(compatibleRounds[i].TagEra) || !sets.Contains(compatibleRounds[i].TagSet))
+                {
+                    compatibleRounds.RemoveAt(i);
+                }
+
+                else if (blacklist != null && !blacklist.IsRoundAllowed(compatibleRounds[i].ItemID))
                 {
                     compatibleRounds.RemoveAt(i);
                 }
@@ -195,18 +203,19 @@ namespace TNHFramework.Utilities
                 {
                     compatibleRounds.RemoveAt(i);
                 }
-
-                else if (!eras.Contains(compatibleRounds[i].TagEra) || !sets.Contains(compatibleRounds[i].TagSet))
-                {
-                    compatibleRounds.RemoveAt(i);
-                }
             }
 
-            foreach (KeyValuePair<FireArmRoundClass, FVRFireArmRoundDisplayData.DisplayDataClass> dogshit in AM.STypeDic[firearm.RoundType])
+            //Get a list of ammo types that cost more than 0 and sort them in descending order by cost
+            var dogshit = AM.STypeDic[firearm.RoundType].Values
+                .Where(x => x.Cost > 0)
+                .OrderByDescending(x => x.Cost);
+
+            //Remove ammo types starting from highest cost. Don't remove if it's the last one left.
+            foreach (var round in dogshit)
             {
-                if (compatibleRounds.Contains(dogshit.Value.ObjectID) && dogshit.Value.Cost > 0)
+                if (compatibleRounds.Count > 1 && compatibleRounds.Contains(round.ObjectID))
                 {
-                    compatibleRounds.Remove(dogshit.Value.ObjectID);
+                    compatibleRounds.Remove(round.ObjectID);
                 }
             }
 

--- a/Utilities/FirearmUtils.cs
+++ b/Utilities/FirearmUtils.cs
@@ -205,17 +205,20 @@ namespace TNHFramework.Utilities
                 }
             }
 
-            //Get a list of ammo types that cost more than 0 and sort them in descending order by cost
-            var dogshit = AM.STypeDic[firearm.RoundType].Values
-                .Where(x => x.Cost > 0)
-                .OrderByDescending(x => x.Cost);
-
-            //Remove ammo types starting from highest cost. Don't remove if it's the last one left.
-            foreach (var round in dogshit)
+            if (AM.STypeDic.ContainsKey(firearm.RoundType))
             {
-                if (compatibleRounds.Count > 1 && compatibleRounds.Contains(round.ObjectID))
+                //Get a list of ammo types that cost more than 0 and sort them in descending order by cost
+                var dogshit = AM.STypeDic[firearm.RoundType].Values
+                    .Where(x => x.Cost > 0)
+                    .OrderByDescending(x => x.Cost);
+
+                //Remove ammo types starting from highest cost. Don't remove if it's the last one left.
+                foreach (var round in dogshit)
                 {
-                    compatibleRounds.Remove(round.ObjectID);
+                    if (compatibleRounds.Count > 1 && compatibleRounds.Contains(round.ObjectID))
+                    {
+                        compatibleRounds.Remove(round.ObjectID);
+                    }
                 }
             }
 


### PR DESCRIPTION
This is a set of small bugfixes:
- Fixed patrol algorithm from skipping patrol types occassionally.
- Fixed the case where the ammo blacklist removes all compatible rounds. It will now leave at least one type of round for each gun at the ammo spawner.
- Fixed panels (ammo reloader, etc.) sometimes breaking when being used a lot.
- Fixed the case where the secondary or tertiary starting item spawn point is missing from the map. This caused some characters to not work on certain maps (e.g. Aporkalypse Now).
- Respect the HasPrimaryWeapon, HasSecondaryWeapon, etc. booleans. Some mod characters have an equipment pool populated, but disabled via boolean. This makes it consistent with old behavior.
- Don't play the announcer line to advance to the next node after finishing the last hold (vanilla bug).